### PR TITLE
Update metadata.php

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -59,7 +59,7 @@ $aModule = array(
             'group'      => 'oxcom_mediaplayer_settings',
             'name'       => 'oxcomMediaplayerSortField',
             'type'       => 'select',
-            'constrains' => 'oxcomplayersort|oxurl|oxdesc|oxtimestamp',
+            'constraints' => 'oxcomplayersort|oxurl|oxdesc|oxtimestamp',
             'value'      => 'oxcomplayersort'
         ],
     ]


### PR DESCRIPTION
Installationerror:

--------
In MetaDataSchemaValidator.php line 96:
                                                                             
  The metadata key "constrains" is not supported in metadata version "2.1".
--------